### PR TITLE
Fix firefox issue, add radius prop

### DIFF
--- a/src/Tree.vue
+++ b/src/Tree.vue
@@ -59,6 +59,10 @@ const props = {
   zoomable: {
     type: Boolean,
     default: false
+  },
+  radius: {
+    type: Number,
+    default: 5
   }
 }
 
@@ -209,7 +213,9 @@ export default {
         .attr('transform', d => translate(d, this.layout))
         .attr('opacity', 1))
 
-      allNodes.append('circle')
+      allNodes
+        .append('circle')
+        .attr('r', this.radius)
 
       text.attr('x', d => { return d.textInfo ? d.textInfo.x : 0 })
           .attr('dx', function (d) { return d.textInfo ? anchorTodx(d.textInfo.anchor, this) : 0 })
@@ -465,13 +471,11 @@ export default {
 <style>
 .treeclass .nodetree  circle {
   fill: #999;
-  r: 2.5;
 }
 
 .treeclass .node--internal circle {
   cursor: pointer;
   fill:  #555;
-  r: 3;
 }
 
 .treeclass .nodetree text {


### PR DESCRIPTION
This PR fixes Firefox's #8 problem when the dots are not displayed correctly, also add new props to set the radius of the dots.